### PR TITLE
Fix stratum user agent to identify as Zyber8S/Zyber8G

### DIFF
--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -380,7 +380,7 @@ int STRATUM_V1_subscribe(int socket, int send_uid, const char * model)
     char subscribe_msg[BUFFER_SIZE];
     const esp_app_desc_t *app_desc = esp_app_get_description();
     const char *version = app_desc->version;	
-    sprintf(subscribe_msg, "{\"id\": %d, \"method\": \"mining.subscribe\", \"params\": [\"bitaxe/%s/%s\"]}\n", send_uid, model, version);
+    sprintf(subscribe_msg, "{\"id\": %d, \"method\": \"mining.subscribe\", \"params\": [\"%s/%s\"]}\n", send_uid, model, version);
     debug_stratum_tx(subscribe_msg);
 
     return write(socket, subscribe_msg, strlen(subscribe_msg));

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -240,7 +240,7 @@ void stratum_primary_heartbeat(void * pvParameters)
         }
 
         int send_uid = 1;
-        STRATUM_V1_subscribe(sock, send_uid++, GLOBAL_STATE->DEVICE_CONFIG.family.asic.name);
+        STRATUM_V1_subscribe(sock, send_uid++, GLOBAL_STATE->DEVICE_CONFIG.family.name);
         STRATUM_V1_authorize(sock, send_uid++, GLOBAL_STATE->SYSTEM_MODULE.pool_user, GLOBAL_STATE->SYSTEM_MODULE.pool_pass);
 
         char recv_buffer[BUFFER_SIZE];
@@ -453,7 +453,7 @@ void stratum_task(void * pvParameters)
         STRATUM_V1_configure_version_rolling(GLOBAL_STATE->sock, GLOBAL_STATE->send_uid++, &GLOBAL_STATE->version_mask);
 
         // mining.subscribe - ID: 2
-        STRATUM_V1_subscribe(GLOBAL_STATE->sock, GLOBAL_STATE->send_uid++, GLOBAL_STATE->DEVICE_CONFIG.family.asic.name);
+        STRATUM_V1_subscribe(GLOBAL_STATE->sock, GLOBAL_STATE->send_uid++, GLOBAL_STATE->DEVICE_CONFIG.family.name);
 
         char * username = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_user : GLOBAL_STATE->SYSTEM_MODULE.pool_user;
         char * password = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_pass : GLOBAL_STATE->SYSTEM_MODULE.pool_pass;


### PR DESCRIPTION
## Summary
- Fix the stratum mining.subscribe user agent which incorrectly identified as `bitaxe/BM1368` or `bitaxe/BM1370`
- Now correctly identifies as `Zyber8S/version` or `Zyber8G/version` depending on the device model

## Changes
- Remove hardcoded `bitaxe/` prefix from stratum subscribe message in `stratum_api.c`
- Use `family.name` instead of `family.asic.name` for device identification in `stratum_task.c`

## Test plan
- [ ] Flash firmware to Zyber8S device and verify pool shows correct user agent
- [ ] Flash firmware to Zyber8G device and verify pool shows correct user agent
